### PR TITLE
Dedup by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 # vendor/
 main
 pod-babashka-fswatcher
+/test/dir

--- a/babashka/ops.go
+++ b/babashka/ops.go
@@ -45,7 +45,7 @@ type ErrorResponse struct {
 
 func ReadMessage() (*Message, error) {
 	reader := bufio.NewReader(os.Stdin)
-	message := &Message{}
+	message := &Message{}//message holds the address of *Message, a pointer
 	if err := bencode.Unmarshal(reader, &message); err != nil {
 		return nil, err
 	}

--- a/babashka/ops.go
+++ b/babashka/ops.go
@@ -45,7 +45,7 @@ type ErrorResponse struct {
 
 func ReadMessage() (*Message, error) {
 	reader := bufio.NewReader(os.Stdin)
-	message := &Message{}//message holds the address of *Message, a pointer
+	message := &Message{}
 	if err := bencode.Unmarshal(reader, &message); err != nil {
 		return nil, err
 	}

--- a/script/test
+++ b/script/test
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
 
 go build -o pod-babashka-fswatcher main.go && test/script.clj
+cd watcher; go test

--- a/test/script.clj
+++ b/test/script.clj
@@ -3,7 +3,8 @@
 (ns script
   (:require [babashka.pods :as pods]
             [clojure.java.shell :refer [sh]]
-            [clojure.test :as t :refer [deftest is testing]]))
+            [clojure.test :as t :refer [deftest is testing]]
+            [clojure.java.io :as io]))
 
 (prn (pods/load-pod "./pod-babashka-fswatcher"))
 
@@ -39,6 +40,54 @@
   (is (= (:path (first ev1)) "test/script.clj"))
   (testing "No new events after unwatch"
     (is (= (count ev1) (count ev2)))))
+
+(deftest dedup-test
+  (reset! events [])
+  (let [watcher (fw/watch "test" #(swap! events conj %) {:delay-ms 50 :recursive true})
+        _ (sh "touch" *file*)
+        _ (Thread/sleep 5)
+        _ (sh "touch" *file*)
+        _ (Thread/sleep 5)
+        _ (sh "touch" *file*)
+        ;;wait for time to end
+        _ (Thread/sleep 51)]
+    (prn :events-dedup @events)
+    (testing "tests that the events that happened inside the interval were deduped."
+      (is (= 1 (count @events))))
+    (fw/unwatch watcher)))
+
+(deftest dedup-outside-interval-test
+  (reset! events [])
+  (let [watcher (fw/watch "test" #(swap! events conj %) {:delay-ms 50 :recursive true})
+        _ (sh "touch" *file*)
+        _ (Thread/sleep 51)
+        _ (sh "touch" *file*)
+        _ (Thread/sleep 51)]
+    (prn :events-dedup-outside-interval @events)
+    (testing "events outside of dedup interval come through."
+      (is (= 2 (count @events))))
+    (fw/unwatch watcher)))
+
+(deftest no-dedup-test
+  (reset! events [])
+  (let [watcher (fw/watch "test" #(swap! events conj %) {:delay-ms 50 :recursive true :dedup false})
+        _ (sh "touch" *file*)
+        _ (Thread/sleep 51)]
+    (prn :events-no-dedup @events)
+    (testing "`dedup :false` won't dedup"
+      (is (not (= 1 (count @events)))))
+    (fw/unwatch watcher)))
+
+(deftest recursive-dedup
+  (let [ev (atom [])
+        file-name "test/dir/anotherdir/bla.txt"
+        _ (clojure.java.io/make-parents file-name)
+        watcher (fw/watch "test" #(swap! ev conj %) {:delay-ms 50 :recursive true})
+        _ (spit file-name "whatever")
+        _ (Thread/sleep 51)]
+    (prn :events-recursive-dedup @ev)
+    (testing "dedup recursive works"
+      (is (= @ev [{:type :write, :path "test/dir/anotherdir/bla.txt"}])))))
 
 (let [{:keys [:fail :error]} (t/run-tests)]
   (System/exit (+ fail error)))

--- a/test/script.clj
+++ b/test/script.clj
@@ -20,7 +20,7 @@
 (def watcher (fw/watch "test" callback {:delay-ms 250 :recursive true}))
 
 (Thread/sleep 200)
-(sh "touch" *file*);;touches current file
+(sh "touch" *file*)
 (Thread/sleep 1000)
 
 (prn :events @events)

--- a/test/script.clj
+++ b/test/script.clj
@@ -49,7 +49,7 @@
         _ (sh "touch" *file*)
         _ (Thread/sleep 5)
         _ (sh "touch" *file*)
-        ;;wait for time to end
+        ;;wait for timer to end
         _ (Thread/sleep 51)]
     (prn :events-dedup @events)
     (testing "tests that the events that happened inside the interval were deduped."

--- a/test/script.clj
+++ b/test/script.clj
@@ -19,7 +19,7 @@
 (def watcher (fw/watch "test" callback {:delay-ms 250 :recursive true}))
 
 (Thread/sleep 200)
-(sh "touch" *file*)
+(sh "touch" *file*);;touches current file
 (Thread/sleep 1000)
 
 (prn :events @events)
@@ -35,8 +35,8 @@
 (def ev2 @events)
 
 (deftest events-test
-  (is (pos? (count ev1)))
-  (is (contains? (set (map :path ev1)) "test/script.clj"))
+  (is (= 1 (count ev1)))
+  (is (= (:path (first ev1)) "test/script.clj"))
   (testing "No new events after unwatch"
     (is (= (count ev1) (count ev2)))))
 

--- a/test/script.clj
+++ b/test/script.clj
@@ -43,14 +43,14 @@
 
 (deftest dedup-test
   (reset! events [])
-  (let [watcher (fw/watch "test" #(swap! events conj %) {:delay-ms 50 :recursive true})
-        _ (sh "touch" *file*)
-        _ (Thread/sleep 5)
-        _ (sh "touch" *file*)
-        _ (Thread/sleep 5)
-        _ (sh "touch" *file*)
-        ;;wait for timer to end
-        _ (Thread/sleep 51)]
+  (let [watcher (fw/watch "test" #(swap! events conj %) {:delay-ms 50 :recursive true})]
+    (sh "touch" *file*)
+    (Thread/sleep 5)
+    (sh "touch" *file*)
+    (Thread/sleep 5)
+    (sh "touch" *file*)
+    ;;wait for timer to end
+    (Thread/sleep 51)
     (prn :events-dedup @events)
     (testing "tests that the events that happened inside the interval were deduped."
       (is (= 1 (count @events))))
@@ -58,11 +58,11 @@
 
 (deftest dedup-outside-interval-test
   (reset! events [])
-  (let [watcher (fw/watch "test" #(swap! events conj %) {:delay-ms 50 :recursive true})
-        _ (sh "touch" *file*)
-        _ (Thread/sleep 51)
-        _ (sh "touch" *file*)
-        _ (Thread/sleep 51)]
+  (let [watcher (fw/watch "test" #(swap! events conj %) {:delay-ms 50 :recursive true})]
+    (sh "touch" *file*)
+    (Thread/sleep 51)
+    (sh "touch" *file*)
+    (Thread/sleep 51)
     (prn :events-dedup-outside-interval @events)
     (testing "events outside of dedup interval come through."
       (is (= 2 (count @events))))
@@ -70,9 +70,9 @@
 
 (deftest no-dedup-test
   (reset! events [])
-  (let [watcher (fw/watch "test" #(swap! events conj %) {:delay-ms 50 :recursive true :dedup false})
-        _ (sh "touch" *file*)
-        _ (Thread/sleep 51)]
+  (let [watcher (fw/watch "test" #(swap! events conj %) {:delay-ms 50 :recursive true :dedup false})]
+    (sh "touch" *file*)
+    (Thread/sleep 51)
     (prn :events-no-dedup @events)
     (testing "`dedup :false` won't dedup"
       (is (not (= 1 (count @events)))))
@@ -82,12 +82,13 @@
   (let [ev (atom [])
         file-name "test/dir/anotherdir/bla.txt"
         _ (clojure.java.io/make-parents file-name)
-        watcher (fw/watch "test" #(swap! ev conj %) {:delay-ms 50 :recursive true})
-        _ (spit file-name "whatever")
-        _ (Thread/sleep 51)]
+        watcher (fw/watch "test" #(swap! ev conj %) {:delay-ms 50 :recursive true})]
+    (spit file-name "whatever")
+    (Thread/sleep 51)
     (prn :events-recursive-dedup @ev)
     (testing "dedup recursive works"
-      (is (= @ev [{:type :write, :path "test/dir/anotherdir/bla.txt"}])))))
+      (is (= @ev [{:type :write, :path "test/dir/anotherdir/bla.txt"}]))
+      (fw/unwatch watcher))))
 
 (let [{:keys [:fail :error]} (t/run-tests)]
   (System/exit (+ fail error)))

--- a/test/script.clj
+++ b/test/script.clj
@@ -50,7 +50,7 @@
     (Thread/sleep 5)
     (sh "touch" *file*)
     ;;wait for timer to end
-    (Thread/sleep 51)
+    (Thread/sleep 60)
     (prn :events-dedup @events)
     (testing "tests that the events that happened inside the interval were deduped."
       (is (= 1 (count @events))))
@@ -62,7 +62,7 @@
     (sh "touch" *file*)
     (Thread/sleep 51)
     (sh "touch" *file*)
-    (Thread/sleep 51)
+    (Thread/sleep 60)
     (prn :events-dedup-outside-interval @events)
     (testing "events outside of dedup interval come through."
       (is (= 2 (count @events))))
@@ -72,19 +72,19 @@
   (reset! events [])
   (let [watcher (fw/watch "test" #(swap! events conj %) {:delay-ms 50 :recursive true :dedup false})]
     (sh "touch" *file*)
-    (Thread/sleep 51)
+    (Thread/sleep 60)
     (prn :events-no-dedup @events)
     (testing "`dedup :false` won't dedup"
       (is (not (= 1 (count @events)))))
     (fw/unwatch watcher)))
 
-(deftest recursive-dedup
+(deftest recursive-dedup-test
   (let [ev (atom [])
         file-name "test/dir/anotherdir/bla.txt"
         _ (clojure.java.io/make-parents file-name)
         watcher (fw/watch "test" #(swap! ev conj %) {:delay-ms 50 :recursive true})]
     (spit file-name "whatever")
-    (Thread/sleep 51)
+    (Thread/sleep 60)
     (prn :events-recursive-dedup @ev)
     (testing "dedup recursive works"
       (is (= @ev [{:type :write, :path "test/dir/anotherdir/bla.txt"}]))

--- a/watcher/ops.go
+++ b/watcher/ops.go
@@ -93,6 +93,7 @@ func dedup(delay time.Duration, input chan fsnotify.Event, dedup bool) chan *fsn
 				t, ok := timers[filepath]
 				mu.Unlock()
 
+				// If there's no timer, create one
 				if !ok {
 					t = time.AfterFunc(math.MaxInt64, func() {
 						output <- &event

--- a/watcher/ops_test.go
+++ b/watcher/ops_test.go
@@ -19,6 +19,7 @@ func TestStartWatcher(t *testing.T) {
 	thisFile := "ops_test.go"
 	delay := 50
 	recursive := true
+	dedup := true
 
 	createMessage := babashka.Message{
 		Op: "invoke", Id: "101", Var: "pod.babashka.fswatcher/-create-watcher", Args: "[101]"}
@@ -26,7 +27,7 @@ func TestStartWatcher(t *testing.T) {
 	startMessage := babashka.Message{
 		Op: "invoke", Id: "2", Var: "pod.babashka.fswatcher/-start-watcher", Args: "[102]"}
 
-	opts := Opts{DelayMs: uint64(delay), Recursive: recursive, Dedup: true}
+	opts := Opts{DelayMs: uint64(delay), Recursive: recursive, Dedup: dedup}
 
 	watcherInfo, err := createWatcher(&createMessage, watchFolder, opts)
 
@@ -36,28 +37,29 @@ func TestStartWatcher(t *testing.T) {
 
 	idx := watcherInfo.WatcherId
 
-	if e := startWatcher(&startMessage, idx); e != nil {
-		fmt.Printf("Error starting watcher: %s", e)
+	if err := startWatcher(&startMessage, idx); err != nil {
+		fmt.Printf("Error starting watcher: %s", err)
 	}
 
 	//touch this file and capture babashka output
 	fsNotifications, err := captureBabashkaOutput(func() error {
 
 		// trying to recreate test/script.clj test
-		time.Sleep(100 * time.Millisecond)
+		time.Sleep(50 * time.Millisecond)
 
-		if ee := os.Chtimes(thisFile, time.Now(), time.Now()); ee != nil {
-			return ee
+		if err := os.Chtimes(thisFile, time.Now(), time.Now()); err != nil {
+			return err
 		}
 
-		//events within delay should be ignored.
+		//events within delay should be deduped.
 		time.Sleep(49 * time.Millisecond)
 
-		if ee := os.Chtimes(thisFile, time.Now(), time.Now()); ee != nil {
-			return ee
+		if err := os.Chtimes(thisFile, time.Now(), time.Now()); err != nil {
+			return err
 		}
 
-		time.Sleep(51 * time.Millisecond)
+		// we wait for the timer to end
+		time.Sleep(60 * time.Millisecond)
 
 		return nil
 	})
@@ -65,8 +67,6 @@ func TestStartWatcher(t *testing.T) {
 	if err != nil {
 		t.Errorf("Error Capturing output: %s", err)
 	}
-
-	fmt.Println(fsNotifications)
 
 	if len(fsNotifications) != 1 {
 		t.Errorf("Expected 1 notification, but got %d", len(fsNotifications))
@@ -80,12 +80,15 @@ func TestStartWatcher(t *testing.T) {
 
 func captureBabashkaOutput(f func() error) ([]Response, error) {
 
+	// restores stdout at the end
 	defer func(orig *os.File) {
 		os.Stdout = orig
 	}(os.Stdout)
 
 	r, w, _ := os.Pipe()
 	os.Stdout = w
+
+	//executes test callback and captures output
 	if err := f(); err != nil {
 		fmt.Print("Failed to touch file and capture output: ", err)
 	}
@@ -95,8 +98,6 @@ func captureBabashkaOutput(f func() error) ([]Response, error) {
 	outString := string(out)
 
 	bencodeStrings := strings.Split(outString, "}e")
-
-	//return bencodeStrings
 
 	responses := []Response{}
 

--- a/watcher/ops_test.go
+++ b/watcher/ops_test.go
@@ -51,7 +51,7 @@ func TestStartWatcher(t *testing.T) {
 		}
 
 		//events within delay should be ignored.
-		time.Sleep(10 * time.Millisecond)
+		time.Sleep(249 * time.Millisecond)
 
 		if ee := os.Chtimes(thisFile, time.Now(), time.Now()); ee != nil {
 			return ee

--- a/watcher/ops_test.go
+++ b/watcher/ops_test.go
@@ -1,14 +1,23 @@
 package watcher
 
 import (
+	//"encoding/json"
 	"fmt"
 	"io"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/jackpal/bencode-go"
+
 	"github.com/babashka/pod-babashka-fswatcher/babashka"
 )
+
+type FileAction struct {
+	Type string `json:"type"`
+	Path string `json:"path"`
+}
 
 func TestStartWatcher(t *testing.T) {
 	message := babashka.Message{
@@ -17,14 +26,14 @@ func TestStartWatcher(t *testing.T) {
 	startMessage := babashka.Message{
 		Op: "invoke", Id: "2", Var: "pod.babashka.fswatcher/-start-watcher", Args: "[102]"}
 
-	opts := Opts{DelayMs: 100, Recursive: false}
-	watcherInfo, err := createWatcher(&message, "ops_test.go", opts)
+	opts := Opts{DelayMs: 50, Recursive: true}
+	watcherInfo, err := createWatcher(&message, ".", opts)
 
 	if err != nil {
 		t.Errorf("Error starting watcher: %s", err)
 	}
 
-	idx := watcherInfo.WatcherId //starts at 1 and is incremented everyime create watcher is called
+	idx := watcherInfo.WatcherId
 
 	defer func(orig *os.File) {
 		os.Stdout = orig
@@ -43,18 +52,68 @@ func TestStartWatcher(t *testing.T) {
 		t.Fatalf("Failed to touch file: %s", err)
 	}
 
-	time.Sleep(3 * time.Second)
+	time.Sleep(100 * time.Millisecond)
+
+	err = os.Chtimes("ops_test.go", time.Now(), time.Now())
+	if err != nil {
+		t.Fatalf("Failed to touch file: %s", err)
+	}
+
+	time.Sleep(100 * time.Millisecond)
 
 	w.Close()
 	out, _ := io.ReadAll(r)
-
-	want := "Hello, World!\n"
 	got := string(out)
-	if got != want {
-		t.Errorf("main() = %v, want %v", got, want)
+	fmt.Println("out:", got)
+	messages := strings.Split(got, "}e")
+
+	// Process each bencode message
+	for _, message := range messages {
+		if len(message) == 0 {
+			continue
+		}
+
+		reader := strings.NewReader(message + "}e")
+
+		// Parse the bencode message into an InvokeResponse struct
+		var response babashka.InvokeResponse
+		err = bencode.Unmarshal(reader, &response)
+		if err != nil {
+			fmt.Printf("Error parsing bencode message: %v\n", err)
+			continue
+		}
+
+		// Process the parsed response as needed
+		fmt.Println("Id:", response)
 	}
 
+	//want := "Hello, World!\n"
+	dataFromFsnotify := babashka.InvokeResponse{}
+	err = bencode.Unmarshal(r, &dataFromFsnotify)
+	if err != nil {
+		t.Fatalf("Failed to touch file: %s", err)
+	}
+
+	//data := whatsthis.(map[string]interface{})["value"]
+	//dataString := data.(string)
+
+	//var action FileAction
+
+	// Parse the JSON string into the FileAction struct
+	//err = json.Unmarshal([]byte(dataString), &action)
+	//if err != nil {
+	//		fmt.Println("Error parsing JSON:", err)
+	//		return
+	//	}
+
+	//	path := action.Path
+	//msg := json.Decoder()
+
+	//if got != want {
+	//	t.Errorf("main() = %v, want %v", got, want)
+	//	}
+
 	//"d2:id1:26:statusl4:donee5:value37:{\"type\":\"chmod\",\"path\":\"ops_test.go\"}e"
-	fmt.Println("out:", got)
+	fmt.Println("out:", dataFromFsnotify)
 
 }

--- a/watcher/ops_test.go
+++ b/watcher/ops_test.go
@@ -1,7 +1,7 @@
 package watcher
 
 import (
-	//"encoding/json"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -14,20 +14,20 @@ import (
 	"github.com/babashka/pod-babashka-fswatcher/babashka"
 )
 
-type FileAction struct {
-	Type string `json:"type"`
-	Path string `json:"path"`
-}
-
 func TestStartWatcher(t *testing.T) {
-	message := babashka.Message{
+
+	watchFolder := "."
+	thisFile := "ops_test.go"
+
+	createMessage := babashka.Message{
 		Op: "invoke", Id: "101", Var: "pod.babashka.fswatcher/-create-watcher", Args: "[101]"}
 
 	startMessage := babashka.Message{
 		Op: "invoke", Id: "2", Var: "pod.babashka.fswatcher/-start-watcher", Args: "[102]"}
 
 	opts := Opts{DelayMs: 50, Recursive: true}
-	watcherInfo, err := createWatcher(&message, ".", opts)
+
+	watcherInfo, err := createWatcher(&createMessage, watchFolder, opts)
 
 	if err != nil {
 		t.Errorf("Error starting watcher: %s", err)
@@ -35,85 +35,82 @@ func TestStartWatcher(t *testing.T) {
 
 	idx := watcherInfo.WatcherId
 
+	if e := startWatcher(&startMessage, idx); e != nil {
+		fmt.Printf("Error starting watcher: %s", e)
+	}
+
+	//touch this file and capture babashka output
+	fsNotifications, err := captureBabashkaOutput(func() error {
+
+		if ee := os.Chtimes(thisFile, time.Now(), time.Now()); ee != nil {
+			return ee
+
+		}
+
+		time.Sleep(100 * time.Millisecond)
+		return nil
+	})
+
+	if err != nil {
+		t.Errorf("Error Capturing output: %s", err)
+	}
+
+	fmt.Print("got:", fsNotifications)
+	//"d2:id1:26:statusl4:donee5:value37:{\"type\":\"chmod\",\"path\":\"ops_test.go\"}e"
+	//but structured
+
+}
+
+func captureBabashkaOutput(f func() error) ([]Response, error) {
+
 	defer func(orig *os.File) {
 		os.Stdout = orig
 	}(os.Stdout)
 
 	r, w, _ := os.Pipe()
 	os.Stdout = w
-	e := startWatcher(&startMessage, idx)
-	if e != nil {
-		fmt.Printf("Error starting watcher: %s", e)
+	if err := f(); err != nil {
+		fmt.Print("Failed to touch file and capture output: ", err)
 	}
-
-	//touch this file
-	err = os.Chtimes("ops_test.go", time.Now(), time.Now())
-	if err != nil {
-		t.Fatalf("Failed to touch file: %s", err)
-	}
-
-	time.Sleep(100 * time.Millisecond)
-
-	err = os.Chtimes("ops_test.go", time.Now(), time.Now())
-	if err != nil {
-		t.Fatalf("Failed to touch file: %s", err)
-	}
-
-	time.Sleep(100 * time.Millisecond)
-
 	w.Close()
 	out, _ := io.ReadAll(r)
-	got := string(out)
-	fmt.Println("out:", got)
-	messages := strings.Split(got, "}e")
+
+	outString := string(out)
+
+	bencodeStrings := strings.Split(outString, "}e")
+
+	//return bencodeStrings
+
+	responses := []Response{}
 
 	// Process each bencode message
-	for _, message := range messages {
-		if len(message) == 0 {
+	for _, bencodeString := range bencodeStrings {
+
+		if len(bencodeString) == 0 {
 			continue
 		}
 
-		reader := strings.NewReader(message + "}e")
+		reader := strings.NewReader(bencodeString + "}e")
 
 		// Parse the bencode message into an InvokeResponse struct
-		var response babashka.InvokeResponse
-		err = bencode.Unmarshal(reader, &response)
-		if err != nil {
-			fmt.Printf("Error parsing bencode message: %v\n", err)
-			continue
+		var babashkaMessage babashka.InvokeResponse
+
+		if err := bencode.Unmarshal(reader, &babashkaMessage); err != nil {
+			return nil, err
 		}
 
-		// Process the parsed response as needed
-		fmt.Println("Id:", response)
+		jsonString := babashkaMessage.Value
+
+		var fsnotifyMsg Response
+		// Parse the JSON string into the FileAction struct
+
+		if err := json.Unmarshal([]byte(jsonString), &fsnotifyMsg); err != nil {
+			return nil, err
+		}		
+
+
+		responses = append(responses, fsnotifyMsg)
 	}
 
-	//want := "Hello, World!\n"
-	dataFromFsnotify := babashka.InvokeResponse{}
-	err = bencode.Unmarshal(r, &dataFromFsnotify)
-	if err != nil {
-		t.Fatalf("Failed to touch file: %s", err)
-	}
-
-	//data := whatsthis.(map[string]interface{})["value"]
-	//dataString := data.(string)
-
-	//var action FileAction
-
-	// Parse the JSON string into the FileAction struct
-	//err = json.Unmarshal([]byte(dataString), &action)
-	//if err != nil {
-	//		fmt.Println("Error parsing JSON:", err)
-	//		return
-	//	}
-
-	//	path := action.Path
-	//msg := json.Decoder()
-
-	//if got != want {
-	//	t.Errorf("main() = %v, want %v", got, want)
-	//	}
-
-	//"d2:id1:26:statusl4:donee5:value37:{\"type\":\"chmod\",\"path\":\"ops_test.go\"}e"
-	fmt.Println("out:", dataFromFsnotify)
-
+	return responses, nil
 }

--- a/watcher/ops_test.go
+++ b/watcher/ops_test.go
@@ -1,0 +1,60 @@
+package watcher
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/babashka/pod-babashka-fswatcher/babashka"
+)
+
+func TestStartWatcher(t *testing.T) {
+	message := babashka.Message{
+		Op: "invoke", Id: "101", Var: "pod.babashka.fswatcher/-create-watcher", Args: "[101]"}
+
+	startMessage := babashka.Message{
+		Op: "invoke", Id: "2", Var: "pod.babashka.fswatcher/-start-watcher", Args: "[102]"}
+
+	opts := Opts{DelayMs: 100, Recursive: false}
+	watcherInfo, err := createWatcher(&message, "ops_test.go", opts)
+
+	if err != nil {
+		t.Errorf("Error starting watcher: %s", err)
+	}
+
+	idx := watcherInfo.WatcherId //starts at 1 and is incremented everyime create watcher is called
+
+	defer func(orig *os.File) {
+		os.Stdout = orig
+	}(os.Stdout)
+
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	e := startWatcher(&startMessage, idx)
+	if e != nil {
+		fmt.Printf("Error starting watcher: %s", e)
+	}
+
+	//touch this file
+	err = os.Chtimes("ops_test.go", time.Now(), time.Now())
+	if err != nil {
+		t.Fatalf("Failed to touch file: %s", err)
+	}
+
+	time.Sleep(3 * time.Second)
+
+	w.Close()
+	out, _ := io.ReadAll(r)
+
+	want := "Hello, World!\n"
+	got := string(out)
+	if got != want {
+		t.Errorf("main() = %v, want %v", got, want)
+	}
+
+	//"d2:id1:26:statusl4:donee5:value37:{\"type\":\"chmod\",\"path\":\"ops_test.go\"}e"
+	fmt.Println("out:", got)
+
+}


### PR DESCRIPTION
Addresses https://github.com/babashka/pod-babashka-fswatcher/issues/18

`fsnotify` was creating many file notifications consecutively, which can be disruptive, for instance, if you have a build tool that gets triggered on file changes.

fsnotify[ has an example of deduping based on timers](https://github.com/fsnotify/fsnotify/blob/main/cmd/fsnotify/dedup.go) that I implemented here, replacing the debounce logic which was letting duplicates come through. 