### PR TITLE
Update fswatcher pod version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ See [test/script.clj](test/script.clj) for an example test script.
 In babashka 0.8.0 it is possible to specify pods in `bb.edn`:
 
 ``` clojure
-{:pods {org.babashka/fswatcher {:version "0.0.5"}}
+{:pods {org.babashka/fswatcher {:version "0.0.7"}}
  :tasks {watch {:requires ([pod.babashka.fswatcher :as fw])
                 :task (do (fw/watch "project.clj"
                                     (fn [event]


### PR DESCRIPTION
0.0.5 doesn't work for me. I was following the README and then I realize that there was a newer version that actually works with my configuration.